### PR TITLE
Feat/export application payement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 
 ### Mac OS ###
 .DS_Store
+.env.*
+.env

--- a/src/main/java/school/hei/vola/endpoint/event/EventProducer.java
+++ b/src/main/java/school/hei/vola/endpoint/event/EventProducer.java
@@ -47,10 +47,13 @@ public class EventProducer<T extends PojaEvent> implements Consumer<Collection<T
   public void accept(Collection<T> events) {
     for (var batch : listGrouper.apply(events.stream().toList(), MAX_EVENTS_FOR_PUT_REQUEST)) {
       log.info("Events to send: {}", batch);
-      PutEventsResponse response = sendRequest(batch);
-      checkResponse(response);
-    }
-  }
+      try{
+	PutEventsResponse response = sendRequest(batch);
+        checkResponse(response);
+      }catch(Exception e){
+      	log.info("Error" + e.getMessage());
+      }
+  }}
 
   private PutEventsRequest toEventsRequest(List<T> events) {
     return PutEventsRequest.builder()

--- a/src/main/java/school/hei/vola/endpoint/event/EventProducer.java
+++ b/src/main/java/school/hei/vola/endpoint/event/EventProducer.java
@@ -47,13 +47,14 @@ public class EventProducer<T extends PojaEvent> implements Consumer<Collection<T
   public void accept(Collection<T> events) {
     for (var batch : listGrouper.apply(events.stream().toList(), MAX_EVENTS_FOR_PUT_REQUEST)) {
       log.info("Events to send: {}", batch);
-      try{
-	PutEventsResponse response = sendRequest(batch);
+      try {
+        PutEventsResponse response = sendRequest(batch);
         checkResponse(response);
-      }catch(Exception e){
-      	log.info("Error" + e.getMessage());
+      } catch (Exception e) {
+        log.info("Error" + e.getMessage());
       }
-  }}
+    }
+  }
 
   private PutEventsRequest toEventsRequest(List<T> events) {
     return PutEventsRequest.builder()

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -57,9 +57,12 @@ public class PaymentController {
       @RequestParam String applicationName,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
-    Instant start = startDate != null ? startDate.atStartOfDay(ZoneOffset.UTC).toInstant() : null;
+    Instant start =
+        startDate != null ? startDate.atStartOfDay(ZoneOffset.UTC).toInstant() : Instant.EPOCH;
     Instant end =
-        endDate != null ? endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant() : null;
+        endDate != null
+            ? endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+            : Instant.parse("9999-12-31T23:59:59Z");
     var csv = paymentService.buildPaymentsCsv(applicationName, start, end);
     return ResponseEntity.ok()
         .header(CONTENT_DISPOSITION, "attachment; filename=payments_" + applicationName + ".csv")

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -18,7 +18,6 @@ import school.hei.vola.endpoint.rest.security.ApplicationAuthorizer;
 import school.hei.vola.model.ImportedTransactionDetails;
 import school.hei.vola.model.Payment;
 import school.hei.vola.model.PaymentInfo;
-import school.hei.vola.model.VerificationStatus;
 import school.hei.vola.model.psp.PspType;
 import school.hei.vola.service.MultipartFileConverter;
 import school.hei.vola.service.OrangeSyncService;
@@ -58,67 +57,14 @@ public class PaymentController {
       @RequestParam String applicationName,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
-    List<Payment> payments;
-    if (startDate != null && endDate != null) {
-      Instant start = startDate.atStartOfDay(ZoneOffset.UTC).toInstant();
-      Instant end = endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
-      payments =
-          paymentService.findPaymentsByApplicationNameAndDateRange(applicationName, start, end);
-    } else {
-      payments = paymentService.findPaymentsByApplicationName(applicationName);
-    }
-    byte[] csv = buildCsv(payments);
+    Instant start = startDate != null ? startDate.atStartOfDay(ZoneOffset.UTC).toInstant() : null;
+    Instant end =
+        endDate != null ? endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant() : null;
+    var csv = paymentService.buildPaymentsCsv(applicationName, start, end);
     return ResponseEntity.ok()
         .header(CONTENT_DISPOSITION, "attachment; filename=payments_" + applicationName + ".csv")
         .header("Content-Type", "text/csv")
-        .body(csv);
-  }
-
-  private byte[] buildCsv(List<Payment> payments) {
-    var sb = new StringBuilder();
-    sb.append(
-        "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"
-            + " v\u00e9rification;Application\n");
-    for (var p : payments) {
-      var amount = p.pspPayment().amount();
-      var status = p.getVerificationStatus();
-      sb.append(escapeCsv(p.payer().email()))
-          .append(';')
-          .append(p.pspPayment().pspType())
-          .append(';')
-          .append(escapeCsv(p.pspPayment().id()))
-          .append(';')
-          .append(amount != null ? amount : "")
-          .append(';')
-          .append(statusLabel(status))
-          .append(';')
-          .append(p.creationInstant() != null ? p.creationInstant().toString() : "")
-          .append(';')
-          .append(
-              p.lastPspVerificationInstant() != null
-                  ? p.lastPspVerificationInstant().toString()
-                  : "")
-          .append(';')
-          .append(p.application().name())
-          .append('\n');
-    }
-    return sb.toString().getBytes();
-  }
-
-  private String escapeCsv(String value) {
-    if (value == null) return "";
-    if (value.contains(";") || value.contains("\"") || value.contains("\n")) {
-      return "\"" + value.replace("\"", "\"\"") + "\"";
-    }
-    return value;
-  }
-
-  private String statusLabel(VerificationStatus status) {
-    return switch (status) {
-      case VERIFYING -> "En vérification";
-      case SUCCEEDED -> "Succès";
-      case FAILED -> "Échoué";
-    };
+        .body(csv.getBytes());
   }
 
   @PutMapping("/payments/search")

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -1,25 +1,29 @@
 package school.hei.vola.endpoint.rest.controller;
 
 import static org.springframework.format.annotation.DateTimeFormat.ISO;
+import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
+import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
-
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import school.hei.vola.endpoint.rest.security.ApplicationAuthorizer;
 import school.hei.vola.model.ImportedTransactionDetails;
 import school.hei.vola.model.Payment;
 import school.hei.vola.model.PaymentInfo;
+import school.hei.vola.model.VerificationStatus;
 import school.hei.vola.model.psp.PspType;
 import school.hei.vola.service.MultipartFileConverter;
 import school.hei.vola.service.OrangeSyncService;
 import school.hei.vola.service.PaymentService;
 import school.hei.vola.service.sync.model.RecoveryResult;
-import java.io.IOException;
 
 @RestController
 @AllArgsConstructor
@@ -49,13 +53,72 @@ public class PaymentController {
         .orElseThrow(NotFoundException::new);
   }
 
-  @GetMapping("/payments")
-  public List<Payment> getPaymentsByApplication(
-      @RequestParam String applicationName, @RequestParam(required = false) String apiKey) {
-    if (apiKey != null) {
-      applicationAuthorizer.accept(apiKey);
+  @GetMapping("/payments/export/csv")
+  public ResponseEntity<byte[]> exportPaymentsCsv(
+      @RequestParam String applicationName,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+    List<Payment> payments;
+    if (startDate != null && endDate != null) {
+      Instant start = startDate.atStartOfDay(ZoneOffset.UTC).toInstant();
+      Instant end = endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+      payments =
+          paymentService.findPaymentsByApplicationNameAndDateRange(applicationName, start, end);
+    } else {
+      payments = paymentService.findPaymentsByApplicationName(applicationName);
     }
-    return paymentService.findPaymentsByApplicationName(applicationName);
+    byte[] csv = buildCsv(payments);
+    return ResponseEntity.ok()
+        .header(CONTENT_DISPOSITION, "attachment; filename=payments_" + applicationName + ".csv")
+        .header("Content-Type", "text/csv")
+        .body(csv);
+  }
+
+  private byte[] buildCsv(List<Payment> payments) {
+    var sb = new StringBuilder();
+    sb.append(
+        "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"
+            + " v\u00e9rification;Application\n");
+    for (var p : payments) {
+      var amount = p.pspPayment().amount();
+      var status = p.getVerificationStatus();
+      sb.append(escapeCsv(p.payer().email()))
+          .append(';')
+          .append(p.pspPayment().pspType())
+          .append(';')
+          .append(escapeCsv(p.pspPayment().id()))
+          .append(';')
+          .append(amount != null ? amount : "")
+          .append(';')
+          .append(statusLabel(status))
+          .append(';')
+          .append(p.creationInstant() != null ? p.creationInstant().toString() : "")
+          .append(';')
+          .append(
+              p.lastPspVerificationInstant() != null
+                  ? p.lastPspVerificationInstant().toString()
+                  : "")
+          .append(';')
+          .append(p.application().name())
+          .append('\n');
+    }
+    return sb.toString().getBytes();
+  }
+
+  private String escapeCsv(String value) {
+    if (value == null) return "";
+    if (value.contains(";") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+
+  private String statusLabel(VerificationStatus status) {
+    return switch (status) {
+      case VERIFYING -> "En vérification";
+      case SUCCEEDED -> "Succès";
+      case FAILED -> "Échoué";
+    };
   }
 
   @PutMapping("/payments/search")

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -3,18 +3,12 @@ package school.hei.vola.endpoint.rest.controller;
 import static org.springframework.format.annotation.DateTimeFormat.ISO;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
+
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import school.hei.vola.endpoint.rest.security.ApplicationAuthorizer;
 import school.hei.vola.model.ImportedTransactionDetails;
@@ -25,6 +19,7 @@ import school.hei.vola.service.MultipartFileConverter;
 import school.hei.vola.service.OrangeSyncService;
 import school.hei.vola.service.PaymentService;
 import school.hei.vola.service.sync.model.RecoveryResult;
+import java.io.IOException;
 
 @RestController
 @AllArgsConstructor
@@ -52,6 +47,15 @@ public class PaymentController {
     return paymentService
         .findPaymentByPayerEmailAndPspTypeAndPspPaymentId(payerEmail, pspType, pspPaymentId)
         .orElseThrow(NotFoundException::new);
+  }
+
+  @GetMapping("/payments")
+  public List<Payment> getPaymentsByApplication(
+      @RequestParam String applicationName, @RequestParam(required = false) String apiKey) {
+    if (apiKey != null) {
+      applicationAuthorizer.accept(apiKey);
+    }
+    return paymentService.findPaymentsByApplicationName(applicationName);
   }
 
   @PutMapping("/payments/search")

--- a/src/main/java/school/hei/vola/model/exception/ApplicationNotFoundException.java
+++ b/src/main/java/school/hei/vola/model/exception/ApplicationNotFoundException.java
@@ -1,0 +1,7 @@
+package school.hei.vola.model.exception;
+
+public class ApplicationNotFoundException extends RuntimeException {
+  public ApplicationNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/school/hei/vola/repository/ApplicationRepository.java
+++ b/src/main/java/school/hei/vola/repository/ApplicationRepository.java
@@ -2,7 +2,6 @@ package school.hei.vola.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Repository;
 import school.hei.vola.model.Application;

--- a/src/main/java/school/hei/vola/repository/ApplicationRepository.java
+++ b/src/main/java/school/hei/vola/repository/ApplicationRepository.java
@@ -1,6 +1,8 @@
 package school.hei.vola.repository;
 
+import java.util.List;
 import java.util.Optional;
+
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Repository;
 import school.hei.vola.model.Application;
@@ -15,5 +17,9 @@ public class ApplicationRepository {
 
   public Optional<Application> findByApiKey(String apiKey) {
     return jApplicationRepository.findByApiKey(apiKey).map(jApplicationMapper::toDomain);
+  }
+
+  public List<Application> findAll() {
+    return jApplicationRepository.findAll().stream().map(jApplicationMapper::toDomain).toList();
   }
 }

--- a/src/main/java/school/hei/vola/repository/PaymentRepository.java
+++ b/src/main/java/school/hei/vola/repository/PaymentRepository.java
@@ -3,6 +3,7 @@ package school.hei.vola.repository;
 import static java.util.UUID.randomUUID;
 import static school.hei.vola.model.Time.millisNow;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -149,6 +150,15 @@ public class PaymentRepository {
 
   public List<Payment> findByApplicationName(String applicationName) {
     return jPaymentRepository.findByApplication_Name(applicationName).stream()
+        .map(jPaymentMapper::toDomain)
+        .toList();
+  }
+
+  public List<Payment> findByApplicationNameAndDateRange(
+      String applicationName, Instant start, Instant end) {
+    return jPaymentRepository
+        .findByApplicationNameAndCreationInstantBetween(applicationName, start, end)
+        .stream()
         .map(jPaymentMapper::toDomain)
         .toList();
   }

--- a/src/main/java/school/hei/vola/repository/PaymentRepository.java
+++ b/src/main/java/school/hei/vola/repository/PaymentRepository.java
@@ -146,4 +146,10 @@ public class PaymentRepository {
         .map(jPaymentMapper::toDomain)
         .toList();
   }
+
+  public List<Payment> findByApplicationName(String applicationName) {
+    return jPaymentRepository.findByApplication_Name(applicationName).stream()
+        .map(jPaymentMapper::toDomain)
+        .toList();
+  }
 }

--- a/src/main/java/school/hei/vola/repository/jpa/JApplicationRepository.java
+++ b/src/main/java/school/hei/vola/repository/jpa/JApplicationRepository.java
@@ -1,5 +1,6 @@
 package school.hei.vola.repository.jpa;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,6 @@ import school.hei.vola.repository.jpa.model.JApplication;
 @Repository
 public interface JApplicationRepository extends JpaRepository<JApplication, String> {
   Optional<JApplication> findByApiKey(String apiKey);
+
+  List<JApplication> findAll();
 }

--- a/src/main/java/school/hei/vola/repository/jpa/JPaymentRepository.java
+++ b/src/main/java/school/hei/vola/repository/jpa/JPaymentRepository.java
@@ -15,4 +15,6 @@ public interface JPaymentRepository extends JpaRepository<JPayment, String> {
 
   Optional<JPayment> findPaymentByPayerEmailAndPspTypeAndPspPaymentId(
       String payerEmail, PspType pspType, String pspPaymentId);
+
+  List<JPayment> findByApplication_Name(String applicationName);
 }

--- a/src/main/java/school/hei/vola/repository/jpa/JPaymentRepository.java
+++ b/src/main/java/school/hei/vola/repository/jpa/JPaymentRepository.java
@@ -1,8 +1,11 @@
 package school.hei.vola.repository.jpa;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import school.hei.vola.model.psp.PspType;
 import school.hei.vola.repository.jpa.model.JPayment;
@@ -17,4 +20,12 @@ public interface JPaymentRepository extends JpaRepository<JPayment, String> {
       String payerEmail, PspType pspType, String pspPaymentId);
 
   List<JPayment> findByApplication_Name(String applicationName);
+
+  @Query(
+      "SELECT p FROM JPayment p WHERE p.application.name = :applicationName "
+          + "AND p.creationInstant >= :start AND p.creationInstant < :end")
+  List<JPayment> findByApplicationNameAndCreationInstantBetween(
+      @Param("applicationName") String applicationName,
+      @Param("start") Instant start,
+      @Param("end") Instant end);
 }

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -94,12 +94,7 @@ public class PaymentService {
   }
 
   public String buildPaymentsCsv(String applicationName, Instant start, Instant end) {
-    List<Payment> payments;
-    if (start != null && end != null) {
-      payments = findPaymentsByApplicationNameAndDateRange(applicationName, start, end);
-    } else {
-      payments = findPaymentsByApplicationName(applicationName);
-    }
+    List<Payment> payments = findPaymentsByApplicationNameAndDateRange(applicationName, start, end);
     var sb = new StringBuilder();
     sb.append(
         "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -82,6 +82,10 @@ public class PaymentService {
     return foundPayments;
   }
 
+  public List<Payment> findPaymentsByApplicationName(String applicationName) {
+    return paymentRepository.findByApplicationName(applicationName);
+  }
+
   public ImportedTransactionDetails saveTransactionFromExcel(File excel) {
     log.info("File name : " + excel.getName());
     var bucketKey = TRANSACTIONS_XLS_IMPORT_BUCKET_KEY + excel.getName();

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -4,6 +4,7 @@ import static java.time.Instant.now;
 
 import jakarta.transaction.Transactional;
 import java.io.File;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -84,6 +85,11 @@ public class PaymentService {
 
   public List<Payment> findPaymentsByApplicationName(String applicationName) {
     return paymentRepository.findByApplicationName(applicationName);
+  }
+
+  public List<Payment> findPaymentsByApplicationNameAndDateRange(
+      String applicationName, Instant start, Instant end) {
+    return paymentRepository.findByApplicationNameAndDateRange(applicationName, start, end);
   }
 
   public ImportedTransactionDetails saveTransactionFromExcel(File excel) {

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -18,6 +18,7 @@ import school.hei.vola.file.bucket.BucketComponent;
 import school.hei.vola.model.ImportedTransactionDetails;
 import school.hei.vola.model.Payment;
 import school.hei.vola.model.PaymentInfo;
+import school.hei.vola.model.VerificationStatus;
 import school.hei.vola.model.psp.PspType;
 import school.hei.vola.repository.OrangePaymentRepository;
 import school.hei.vola.repository.PaymentRepository;
@@ -90,6 +91,58 @@ public class PaymentService {
   public List<Payment> findPaymentsByApplicationNameAndDateRange(
       String applicationName, Instant start, Instant end) {
     return paymentRepository.findByApplicationNameAndDateRange(applicationName, start, end);
+  }
+
+  public String buildPaymentsCsv(String applicationName, Instant start, Instant end) {
+    List<Payment> payments;
+    if (start != null && end != null) {
+      payments = findPaymentsByApplicationNameAndDateRange(applicationName, start, end);
+    } else {
+      payments = findPaymentsByApplicationName(applicationName);
+    }
+    var sb = new StringBuilder();
+    sb.append(
+        "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"
+            + " v\u00e9rification;Application\n");
+    for (var p : payments) {
+      var amount = p.pspPayment().amount();
+      sb.append(escapeCsv(p.payer().email()))
+          .append(';')
+          .append(p.pspPayment().pspType())
+          .append(';')
+          .append(escapeCsv(p.pspPayment().id()))
+          .append(';')
+          .append(amount != null ? amount : "")
+          .append(';')
+          .append(statusLabel(p.getVerificationStatus()))
+          .append(';')
+          .append(p.creationInstant() != null ? p.creationInstant().toString() : "")
+          .append(';')
+          .append(
+              p.lastPspVerificationInstant() != null
+                  ? p.lastPspVerificationInstant().toString()
+                  : "")
+          .append(';')
+          .append(p.application().name())
+          .append('\n');
+    }
+    return sb.toString();
+  }
+
+  private String escapeCsv(String value) {
+    if (value == null) return "";
+    if (value.contains(";") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+
+  private String statusLabel(VerificationStatus status) {
+    return switch (status) {
+      case VERIFYING -> "En vérification";
+      case SUCCEEDED -> "Succès";
+      case FAILED -> "Échoué";
+    };
   }
 
   public ImportedTransactionDetails saveTransactionFromExcel(File excel) {


### PR DESCRIPTION
## Summary

Add a new endpoint `GET /payments/export/csv` to export payments of an application as CSV.

## Endpoint

GET /payments/export/csv?applicationName=<name>&startDate=2007-04-07&endDate=2007-07-10

- `applicationName` — required
- `startDate` / `endDate` — If both are provided, filters by creation date range. If omitted, exports the full history.
Case when only one is given also handled.

## Changes

- **`PaymentController`** — added CSV export endpoint
- **`PaymentService`** — added `buildPaymentsCsv()` with CSV building logic + helper methods
- **`PaymentRepository`** — added `findByApplicationNameAndDateRange()`
- **`JPaymentRepository`** — added JPQL query filtering by application name and creation instant range

## CSV format

Columns: `Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date création;Dernière vérification;Application`