### PR TITLE
feat: add CSV export for payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### Mac OS ###
 .DS_Store
+.env

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package school.hei.vola.endpoint.rest.controller;
 
+import static java.lang.System.currentTimeMillis;
 import static org.springframework.format.annotation.DateTimeFormat.ISO;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
@@ -77,7 +78,7 @@ public class PaymentController {
 
     var csv = paymentService.buildPaymentsCsv(applicationName, scope, start, end);
     var displayName = applicationName != null ? applicationName : "all";
-    var filename = "payments_" + displayName + "_" + System.currentTimeMillis() + ".csv";
+    var filename = "payments_" + displayName + "_" + currentTimeMillis() + ".csv";
 
     return ResponseEntity.ok()
         .header(CONTENT_DISPOSITION, "attachment; filename=" + filename)

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -1,13 +1,17 @@
 package school.hei.vola.endpoint.rest.controller;
 
 import static org.springframework.format.annotation.DateTimeFormat.ISO;
+import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -56,6 +60,28 @@ public class PaymentController {
     return paymentService
         .findPaymentByPayerEmailAndPspTypeAndPspPaymentId(payerEmail, pspType, pspPaymentId)
         .orElseThrow(NotFoundException::new);
+  }
+
+  @GetMapping("/payments/export/csv")
+  public ResponseEntity<byte[]> exportPaymentsCsv(
+      @RequestParam String applicationName,
+      @RequestParam(required = false) String scope,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+    Instant start =
+        startDate != null ? startDate.atStartOfDay(ZoneOffset.UTC).toInstant() : Instant.EPOCH;
+    Instant end =
+        endDate != null
+            ? endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
+            : Instant.now();
+
+    var csv = paymentService.buildPaymentsCsv(applicationName, scope, start, end);
+    var filename = "payments_" + applicationName + "_" + System.currentTimeMillis() + ".csv";
+
+    return ResponseEntity.ok()
+        .header(CONTENT_DISPOSITION, "attachment; filename=" + filename)
+        .header("Content-Type", "text/csv")
+        .body(csv.getBytes());
   }
 
   @PutMapping("/payments/search")

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import school.hei.vola.endpoint.rest.security.AdminAuthorizer;
 import school.hei.vola.endpoint.rest.security.ApplicationAuthorizer;
 import school.hei.vola.model.ImportedTransactionDetails;
 import school.hei.vola.model.Payment;
@@ -37,6 +38,7 @@ public class PaymentController {
 
   private final PaymentService paymentService;
   private final ApplicationAuthorizer applicationAuthorizer;
+  private final AdminAuthorizer adminAuthorizer;
   private final OrangeSyncService recoveryService;
   private final MultipartFileConverter multipartFileConverter;
 
@@ -66,15 +68,16 @@ public class PaymentController {
   @GetMapping("/payments/export/csv")
   public ResponseEntity<byte[]> exportPaymentsCsv(
       @RequestParam String apiKey,
+      @RequestParam String applicationName,
       @RequestParam(required = false) String scope,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
-    applicationAuthorizer.accept(apiKey);
+    adminAuthorizer.accept(apiKey);
     var start = startDate != null ? startDate.atStartOfDay(UTC).toInstant() : Instant.EPOCH;
     var end = endDate != null ? endDate.plusDays(1).atStartOfDay(UTC).toInstant() : Instant.now();
 
-    var csv = paymentService.buildPaymentsCsv(apiKey, scope, start, end);
-    var filename = "payments_export_" + currentTimeMillis() + ".csv";
+    var csv = paymentService.buildPaymentsCsv(applicationName, scope, start, end);
+    var filename = "payments_" + applicationName + "_" + currentTimeMillis() + ".csv";
 
     return ResponseEntity.ok()
         .header(CONTENT_DISPOSITION, "attachment; filename=" + filename)

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -67,12 +67,12 @@ public class PaymentController {
 
   @GetMapping("/payments/export/csv")
   public ResponseEntity<byte[]> exportPaymentsCsv(
-      @RequestParam String apiKey,
+      @RequestParam String adminKey,
       @RequestParam String applicationName,
       @RequestParam(required = false) String scope,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
-    adminAuthorizer.accept(apiKey);
+    adminAuthorizer.accept(adminKey);
     var start = startDate != null ? startDate.atStartOfDay(UTC).toInstant() : Instant.EPOCH;
     var end = endDate != null ? endDate.plusDays(1).atStartOfDay(UTC).toInstant() : Instant.now();
 

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -1,17 +1,17 @@
 package school.hei.vola.endpoint.rest.controller;
 
 import static java.lang.System.currentTimeMillis;
-import static org.springframework.format.annotation.DateTimeFormat.ISO;
+import static java.time.ZoneOffset.UTC;
 import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -69,12 +69,8 @@ public class PaymentController {
       @RequestParam(required = false) String scope,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
-    Instant start =
-        startDate != null ? startDate.atStartOfDay(ZoneOffset.UTC).toInstant() : Instant.EPOCH;
-    Instant end =
-        endDate != null
-            ? endDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
-            : Instant.now();
+    var start = startDate != null ? startDate.atStartOfDay(UTC).toInstant() : Instant.EPOCH;
+    var end = endDate != null ? endDate.plusDays(1).atStartOfDay(UTC).toInstant() : Instant.now();
 
     var csv = paymentService.buildPaymentsCsv(applicationName, scope, start, end);
     var displayName = applicationName != null ? applicationName : "all";

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -64,7 +64,7 @@ public class PaymentController {
 
   @GetMapping("/payments/export/csv")
   public ResponseEntity<byte[]> exportPaymentsCsv(
-      @RequestParam String applicationName,
+      @RequestParam(required = false) String applicationName,
       @RequestParam(required = false) String scope,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
@@ -76,7 +76,8 @@ public class PaymentController {
             : Instant.now();
 
     var csv = paymentService.buildPaymentsCsv(applicationName, scope, start, end);
-    var filename = "payments_" + applicationName + "_" + System.currentTimeMillis() + ".csv";
+    var displayName = applicationName != null ? applicationName : "all";
+    var filename = "payments_" + displayName + "_" + System.currentTimeMillis() + ".csv";
 
     return ResponseEntity.ok()
         .header(CONTENT_DISPOSITION, "attachment; filename=" + filename)

--- a/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/controller/PaymentController.java
@@ -65,16 +65,16 @@ public class PaymentController {
 
   @GetMapping("/payments/export/csv")
   public ResponseEntity<byte[]> exportPaymentsCsv(
-      @RequestParam(required = false) String applicationName,
+      @RequestParam String apiKey,
       @RequestParam(required = false) String scope,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+    applicationAuthorizer.accept(apiKey);
     var start = startDate != null ? startDate.atStartOfDay(UTC).toInstant() : Instant.EPOCH;
     var end = endDate != null ? endDate.plusDays(1).atStartOfDay(UTC).toInstant() : Instant.now();
 
-    var csv = paymentService.buildPaymentsCsv(applicationName, scope, start, end);
-    var displayName = applicationName != null ? applicationName : "all";
-    var filename = "payments_" + displayName + "_" + currentTimeMillis() + ".csv";
+    var csv = paymentService.buildPaymentsCsv(apiKey, scope, start, end);
+    var filename = "payments_export_" + currentTimeMillis() + ".csv";
 
     return ResponseEntity.ok()
         .header(CONTENT_DISPOSITION, "attachment; filename=" + filename)

--- a/src/main/java/school/hei/vola/endpoint/rest/security/AdminAuthorizer.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/security/AdminAuthorizer.java
@@ -1,0 +1,21 @@
+package school.hei.vola.endpoint.rest.security;
+
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import school.hei.vola.repository.ApplicationRepository;
+
+@Component
+@AllArgsConstructor
+public class AdminAuthorizer implements Consumer<String> {
+
+  private final ApplicationRepository applicationRepository;
+
+  @Override
+  public void accept(String apiKey) {
+    var app = applicationRepository.findByApiKey(apiKey);
+    if (app.isEmpty() || !"ADMIN".equals(app.get().name())) {
+      throw new UnauthorizedException();
+    }
+  }
+}

--- a/src/main/java/school/hei/vola/endpoint/rest/security/AdminAuthorizer.java
+++ b/src/main/java/school/hei/vola/endpoint/rest/security/AdminAuthorizer.java
@@ -1,20 +1,21 @@
 package school.hei.vola.endpoint.rest.security;
 
 import java.util.function.Consumer;
-import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import school.hei.vola.repository.ApplicationRepository;
 
 @Component
-@AllArgsConstructor
 public class AdminAuthorizer implements Consumer<String> {
 
-  private final ApplicationRepository applicationRepository;
+  private final String adminApiKey;
+
+  public AdminAuthorizer(@Value("${ADMIN_API_KEY}") String adminApiKey) {
+    this.adminApiKey = adminApiKey;
+  }
 
   @Override
   public void accept(String apiKey) {
-    var app = applicationRepository.findByApiKey(apiKey);
-    if (app.isEmpty() || !"ADMIN".equals(app.get().name())) {
+    if (!adminApiKey.equals(apiKey)) {
       throw new UnauthorizedException();
     }
   }

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -22,7 +22,6 @@ import school.hei.vola.model.Payment;
 import school.hei.vola.model.PaymentInfo;
 import school.hei.vola.model.VerificationStatus;
 import school.hei.vola.model.psp.PspType;
-import school.hei.vola.repository.ApplicationRepository;
 import school.hei.vola.repository.OrangePaymentRepository;
 import school.hei.vola.repository.PaymentRepository;
 import school.hei.vola.service.utils.ExcelParser;
@@ -35,7 +34,6 @@ public class PaymentService {
   private static final String TRANSACTIONS_XLS_IMPORT_BUCKET_KEY = "/TRANSACTIONS_XLS_IMPORT/";
 
   private final PaymentRepository paymentRepository;
-  private final ApplicationRepository applicationRepository;
   private final EventProducer eventProducer;
   private final OrangePaymentRepository orangePaymentRepository;
   private final ExcelParser excelParser;
@@ -124,10 +122,9 @@ public class PaymentService {
     return paymentRepository.findDistinctScopes(applicationName);
   }
 
-  public String buildPaymentsCsv(String apiKey, String scope, Instant start, Instant end) {
-    var app = applicationRepository.findByApiKey(apiKey).orElseThrow();
+  public String buildPaymentsCsv(String applicationName, String scope, Instant start, Instant end) {
     List<Payment> payments =
-        findPaymentsByApplicationNameAndDateRange(app.name(), scope, start, end);
+        findPaymentsByApplicationNameAndDateRange(applicationName, scope, start, end);
 
     var header =
         "Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last"

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -20,6 +20,7 @@ import school.hei.vola.file.bucket.BucketComponent;
 import school.hei.vola.model.ImportedTransactionDetails;
 import school.hei.vola.model.Payment;
 import school.hei.vola.model.PaymentInfo;
+import school.hei.vola.model.VerificationStatus;
 import school.hei.vola.model.psp.PspType;
 import school.hei.vola.repository.OrangePaymentRepository;
 import school.hei.vola.repository.PaymentRepository;
@@ -119,6 +120,56 @@ public class PaymentService {
 
   public List<String> findDistinctScopes(String applicationName) {
     return paymentRepository.findDistinctScopes(applicationName);
+  }
+
+  public String buildPaymentsCsv(String applicationName, String scope, Instant start, Instant end) {
+    List<Payment> payments =
+        findPaymentsByApplicationNameAndDateRange(applicationName, scope, start, end);
+    var sb = new StringBuilder();
+    sb.append(
+        "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"
+            + " v\u00e9rification;Scope;Application\n");
+    for (var p : payments) {
+      var amount = p.pspPayment().amount();
+      sb.append(escapeCsv(p.payer().email()))
+          .append(';')
+          .append(p.pspPayment().pspType())
+          .append(';')
+          .append(escapeCsv(p.pspPayment().id()))
+          .append(';')
+          .append(amount != null ? amount : "")
+          .append(';')
+          .append(statusLabel(p.getVerificationStatus()))
+          .append(';')
+          .append(p.creationInstant() != null ? p.creationInstant().toString() : "")
+          .append(';')
+          .append(
+              p.lastPspVerificationInstant() != null
+                  ? p.lastPspVerificationInstant().toString()
+                  : "")
+          .append(';')
+          .append(escapeCsv(p.scope()))
+          .append(';')
+          .append(p.application().name())
+          .append('\n');
+    }
+    return sb.toString();
+  }
+
+  private String escapeCsv(String value) {
+    if (value == null) return "";
+    if (value.contains(";") || value.contains("\"") || value.contains("\n")) {
+      return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+    return value;
+  }
+
+  private String statusLabel(VerificationStatus status) {
+    return switch (status) {
+      case VERIFYING -> "En vérification";
+      case SUCCEEDED -> "Succès";
+      case FAILED -> "Échoué";
+    };
   }
 
   public ImportedTransactionDetails saveTransactionFromExcel(File excel) {

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -22,6 +22,7 @@ import school.hei.vola.model.Payment;
 import school.hei.vola.model.PaymentInfo;
 import school.hei.vola.model.VerificationStatus;
 import school.hei.vola.model.psp.PspType;
+import school.hei.vola.repository.ApplicationRepository;
 import school.hei.vola.repository.OrangePaymentRepository;
 import school.hei.vola.repository.PaymentRepository;
 import school.hei.vola.service.utils.ExcelParser;
@@ -34,6 +35,7 @@ public class PaymentService {
   private static final String TRANSACTIONS_XLS_IMPORT_BUCKET_KEY = "/TRANSACTIONS_XLS_IMPORT/";
 
   private final PaymentRepository paymentRepository;
+  private final ApplicationRepository applicationRepository;
   private final EventProducer eventProducer;
   private final OrangePaymentRepository orangePaymentRepository;
   private final ExcelParser excelParser;
@@ -122,9 +124,10 @@ public class PaymentService {
     return paymentRepository.findDistinctScopes(applicationName);
   }
 
-  public String buildPaymentsCsv(String applicationName, String scope, Instant start, Instant end) {
+  public String buildPaymentsCsv(String apiKey, String scope, Instant start, Instant end) {
+    var app = applicationRepository.findByApiKey(apiKey).orElseThrow();
     List<Payment> payments =
-        findPaymentsByApplicationNameAndDateRange(applicationName, scope, start, end);
+        findPaymentsByApplicationNameAndDateRange(app.name(), scope, start, end);
 
     var header =
         "Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last"

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -133,19 +133,20 @@ public class PaymentService {
 
     for (var p : payments) {
       var amount = p.pspPayment().amount();
-      builder.append(String.format(
-          "%s;%s;%s;%s;%s;%s;%s;%s;%s\n",
-          escapeCsv(p.payer().email()),
-          p.pspPayment().pspType(),
-          escapeCsv(p.pspPayment().id()),
-          amount != null ? amount : "",
-          statusLabel(p.getVerificationStatus()),
-          p.creationInstant() != null ? p.creationInstant().toString() : "",
-          p.lastPspVerificationInstant() != null
-              ? p.lastPspVerificationInstant().toString()
-              : "",
-          escapeCsv(p.scope()),
-          p.application().name()));
+      builder.append(
+          String.format(
+              "%s;%s;%s;%s;%s;%s;%s;%s;%s\n",
+              escapeCsv(p.payer().email()),
+              p.pspPayment().pspType(),
+              escapeCsv(p.pspPayment().id()),
+              amount != null ? amount : "",
+              statusLabel(p.getVerificationStatus()),
+              p.creationInstant() != null ? p.creationInstant().toString() : "",
+              p.lastPspVerificationInstant() != null
+                  ? p.lastPspVerificationInstant().toString()
+                  : "",
+              escapeCsv(p.scope()),
+              p.application().name()));
     }
     return builder.toString();
   }

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -131,25 +131,21 @@ public class PaymentService {
             + " verification;Scope;Application\n";
     var builder = new StringBuilder(header);
 
-    var format = "%s;%s;%s;%s;%s;%s;%s;%s;%s\n";
-
     for (var p : payments) {
       var amount = p.pspPayment().amount();
-      var line =
-          String.format(
-              format,
-              escapeCsv(p.payer().email()),
-              p.pspPayment().pspType(),
-              escapeCsv(p.pspPayment().id()),
-              amount != null ? amount : "",
-              statusLabel(p.getVerificationStatus()),
-              p.creationInstant() != null ? p.creationInstant().toString() : "",
-              p.lastPspVerificationInstant() != null
-                  ? p.lastPspVerificationInstant().toString()
-                  : "",
-              escapeCsv(p.scope()),
-              p.application().name());
-      builder.append(line);
+      builder.append(String.format(
+          "%s;%s;%s;%s;%s;%s;%s;%s;%s\n",
+          escapeCsv(p.payer().email()),
+          p.pspPayment().pspType(),
+          escapeCsv(p.pspPayment().id()),
+          amount != null ? amount : "",
+          statusLabel(p.getVerificationStatus()),
+          p.creationInstant() != null ? p.creationInstant().toString() : "",
+          p.lastPspVerificationInstant() != null
+              ? p.lastPspVerificationInstant().toString()
+              : "",
+          escapeCsv(p.scope()),
+          p.application().name()));
     }
     return builder.toString();
   }

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -127,8 +127,8 @@ public class PaymentService {
         findPaymentsByApplicationNameAndDateRange(applicationName, scope, start, end);
 
     var header =
-        "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"
-            + " v\u00e9rification;Scope;Application\n";
+        "Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last"
+            + " verification;Scope;Application\n";
     var builder = new StringBuilder(header);
 
     var format = "%s;%s;%s;%s;%s;%s;%s;%s;%s\n";
@@ -164,9 +164,9 @@ public class PaymentService {
 
   private String statusLabel(VerificationStatus status) {
     return switch (status) {
-      case VERIFYING -> "En vérification";
-      case SUCCEEDED -> "Succès";
-      case FAILED -> "Échoué";
+      case VERIFYING -> "Verifying";
+      case SUCCEEDED -> "Succeeded";
+      case FAILED -> "Failed";
     };
   }
 

--- a/src/main/java/school/hei/vola/service/PaymentService.java
+++ b/src/main/java/school/hei/vola/service/PaymentService.java
@@ -125,35 +125,33 @@ public class PaymentService {
   public String buildPaymentsCsv(String applicationName, String scope, Instant start, Instant end) {
     List<Payment> payments =
         findPaymentsByApplicationNameAndDateRange(applicationName, scope, start, end);
-    var sb = new StringBuilder();
-    sb.append(
+
+    var header =
         "Email payeur;PSP;Ref paiement;Montant (Ar);Statut;Date cr\u00e9ation;Derni\u00e8re"
-            + " v\u00e9rification;Scope;Application\n");
+            + " v\u00e9rification;Scope;Application\n";
+    var builder = new StringBuilder(header);
+
+    var format = "%s;%s;%s;%s;%s;%s;%s;%s;%s\n";
+
     for (var p : payments) {
       var amount = p.pspPayment().amount();
-      sb.append(escapeCsv(p.payer().email()))
-          .append(';')
-          .append(p.pspPayment().pspType())
-          .append(';')
-          .append(escapeCsv(p.pspPayment().id()))
-          .append(';')
-          .append(amount != null ? amount : "")
-          .append(';')
-          .append(statusLabel(p.getVerificationStatus()))
-          .append(';')
-          .append(p.creationInstant() != null ? p.creationInstant().toString() : "")
-          .append(';')
-          .append(
+      var line =
+          String.format(
+              format,
+              escapeCsv(p.payer().email()),
+              p.pspPayment().pspType(),
+              escapeCsv(p.pspPayment().id()),
+              amount != null ? amount : "",
+              statusLabel(p.getVerificationStatus()),
+              p.creationInstant() != null ? p.creationInstant().toString() : "",
               p.lastPspVerificationInstant() != null
                   ? p.lastPspVerificationInstant().toString()
-                  : "")
-          .append(';')
-          .append(escapeCsv(p.scope()))
-          .append(';')
-          .append(p.application().name())
-          .append('\n');
+                  : "",
+              escapeCsv(p.scope()),
+              p.application().name());
+      builder.append(line);
     }
-    return sb.toString();
+    return builder.toString();
   }
 
   private String escapeCsv(String value) {

--- a/src/test/java/school/hei/vola/conf/EnvConf.java
+++ b/src/test/java/school/hei/vola/conf/EnvConf.java
@@ -11,5 +11,6 @@ public class EnvConf {
     registry.add("spring.datasource.driverClassName", () -> "org.h2.Driver");
     registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.H2Dialect");
     registry.add("orange.api.url", () -> apiUrl);
+    registry.add("ADMIN_API_KEY", () -> "admin-api-key");
   }
 }

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -293,36 +293,6 @@ class PaymentControllerIT extends FacadeIT {
     assertTrue(disposition.contains("payments_" + appName + "_"));
   }
 
-  @Test
-  void exportPaymentsCsv_with_all_returns_payments_from_all_apps() {
-    var app1 = randomJApplication();
-    var app2 = randomJApplication();
-    var email1 = randomEmail();
-    var email2 = randomEmail();
-
-    subject.createPayment(app1.getApiKey(), email1, ORANGE_MONEY, randomUUID().toString(), null);
-    subject.createPayment(app2.getApiKey(), email2, ORANGE_MONEY, randomUUID().toString(), null);
-
-    var response = subject.exportPaymentsCsv("all", null, null, null);
-
-    assertEquals(200, response.getStatusCodeValue());
-    var body = new String(response.getBody());
-    assertTrue(body.contains(email1));
-    assertTrue(body.contains(email2));
-  }
-
-  @Test
-  void exportPaymentsCsv_with_all_uses_all_in_filename() {
-    var app = randomJApplication();
-    subject.createPayment(
-        app.getApiKey(), randomEmail(), ORANGE_MONEY, randomUUID().toString(), null);
-
-    var response = subject.exportPaymentsCsv("all", null, null, null);
-
-    var disposition = response.getHeaders().get(CONTENT_DISPOSITION).getFirst();
-    assertTrue(disposition.contains("payments_all_"));
-  }
-
   private static String randomEmail() {
     return "lou+" + randomUUID() + "@cute.dev";
   }

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -5,6 +5,7 @@ import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,7 @@ import school.hei.vola.endpoint.event.EventProducer;
 import school.hei.vola.endpoint.event.model.OrangeDailyTransactionsRetrievalRequested;
 import school.hei.vola.endpoint.event.model.OrangeTransactionsImportRequested;
 import school.hei.vola.endpoint.event.model.PaymentVerificationRequested;
+import school.hei.vola.endpoint.rest.security.UnauthorizedException;
 import school.hei.vola.file.bucket.BucketComponent;
 import school.hei.vola.model.Application;
 import school.hei.vola.model.Payment;
@@ -236,6 +238,12 @@ class PaymentControllerIT extends FacadeIT {
   @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
   void exportPaymentsCsv_with_data_matches_expected() throws IOException {
+    var admin = new JApplication();
+    admin.setName("ADMIN");
+    admin.setId("admin-app");
+    admin.setApiKey("admin-api-key");
+    jApplicationRepository.save(admin);
+
     var app = new JApplication();
     app.setName("klioba");
     app.setId("app-klioba");
@@ -254,7 +262,7 @@ class PaymentControllerIT extends FacadeIT {
             .application(new Application("klioba", "klioba-api-key"))
             .build());
 
-    var response = subject.exportPaymentsCsv("klioba-api-key", null, null, null);
+    var response = subject.exportPaymentsCsv("admin-api-key", "klioba", null, null, null);
     assertNotNull(response.getBody());
     var csv = new String(response.getBody(), StandardCharsets.UTF_8);
 
@@ -265,13 +273,19 @@ class PaymentControllerIT extends FacadeIT {
   @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
   void exportPaymentsCsv_empty_returns_header_only() throws IOException {
+    var admin = new JApplication();
+    admin.setName("ADMIN");
+    admin.setId("admin-app");
+    admin.setApiKey("admin-api-key");
+    jApplicationRepository.save(admin);
+
     var app = new JApplication();
     app.setName("EmptyApp");
     app.setId("app-empty");
     app.setApiKey("empty-api-key");
     jApplicationRepository.save(app);
 
-    var response = subject.exportPaymentsCsv("empty-api-key", null, null, null);
+    var response = subject.exportPaymentsCsv("admin-api-key", "EmptyApp", null, null, null);
     assertNotNull(response.getBody());
     var csv = new String(response.getBody(), StandardCharsets.UTF_8);
 
@@ -280,6 +294,26 @@ class PaymentControllerIT extends FacadeIT {
         "Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last"
             + " verification;Scope;Application\n",
         csv);
+  }
+
+  @Test
+  void exportPaymentsCsv_invalid_apiKey_throws_401() {
+    assertThrows(
+        UnauthorizedException.class,
+        () -> subject.exportPaymentsCsv("non-existent-key", "klioba", null, null, null));
+  }
+
+  @Test
+  void exportPaymentsCsv_app_apiKey_rejected() {
+    var app = new JApplication();
+    app.setName("klioba");
+    app.setId("app-klioba");
+    app.setApiKey("klioba-api-key");
+    jApplicationRepository.save(app);
+
+    assertThrows(
+        UnauthorizedException.class,
+        () -> subject.exportPaymentsCsv("klioba-api-key", "klioba", null, null, null));
   }
 
   private String readResource() throws IOException {

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.test.annotation.DirtiesContext.MethodMode.BEFORE_METHOD;
 import static school.hei.vola.conf.TestData.ORANGE_REF_SUCCEEDED;
 import static school.hei.vola.model.VerificationStatus.FAILED;
@@ -17,6 +16,7 @@ import static school.hei.vola.model.VerificationStatus.VERIFYING;
 import static school.hei.vola.model.psp.PspType.ORANGE_MONEY;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import school.hei.vola.conf.FacadeIT;
@@ -35,6 +36,12 @@ import school.hei.vola.endpoint.event.model.OrangeDailyTransactionsRetrievalRequ
 import school.hei.vola.endpoint.event.model.OrangeTransactionsImportRequested;
 import school.hei.vola.endpoint.event.model.PaymentVerificationRequested;
 import school.hei.vola.file.bucket.BucketComponent;
+import school.hei.vola.model.Application;
+import school.hei.vola.model.Payment;
+import school.hei.vola.model.User;
+import school.hei.vola.model.psp.PspPayment;
+import school.hei.vola.repository.PaymentRepository;
+import school.hei.vola.repository.UserRepository;
 import school.hei.vola.repository.jpa.JApplicationRepository;
 import school.hei.vola.repository.jpa.model.JApplication;
 import school.hei.vola.service.event.OrangeDailyTransactionsRetrievalRequestedService;
@@ -55,6 +62,9 @@ class PaymentControllerIT extends FacadeIT {
   @Autowired private PaymentVerificationRequestedService paymentVerificationRequestedService;
 
   @Autowired JApplicationRepository jApplicationRepository;
+
+  @Autowired private PaymentRepository paymentRepository;
+  @Autowired private UserRepository userRepository;
 
   JApplication randomJApplication() {
     var jApplication = new JApplication();
@@ -223,74 +233,78 @@ class PaymentControllerIT extends FacadeIT {
     assertTrue(events.getFirst().getBucketKey().contains(bucketKey));
   }
 
+  @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
-  void exportPaymentsCsv_returns_csv_with_correct_headers() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
+  void exportPaymentsCsv_with_data_matches_expected() throws IOException {
+    var klioba = new JApplication();
+    klioba.setName("klioba");
+    klioba.setId("app-klioba");
+    klioba.setApiKey("klioba-api-key");
+    jApplicationRepository.save(klioba);
 
-    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+    var tsinjo = new JApplication();
+    tsinjo.setName("tsinjo");
+    tsinjo.setId("app-tsinjo");
+    tsinjo.setApiKey("tsinjo-api-key");
+    jApplicationRepository.save(tsinjo);
 
-    var response = subject.exportPaymentsCsv(appName, null, null, null);
+    userRepository.save(new User("mata@cu.te"));
+
+    paymentRepository.save(
+        Payment.builder()
+            .id("p1")
+            .pspPayment(
+                PspPayment.builder().pspType(ORANGE_MONEY).id("MP260715.1234.A1B2C3").build())
+            .creationInstant(Instant.parse("2026-01-15T10:30:00Z"))
+            .verificationAttemptNb(0)
+            .payer(new User("mata@cu.te"))
+            .application(new Application("klioba", "klioba-api-key"))
+            .build());
+
+    paymentRepository.save(
+        Payment.builder()
+            .id("p2")
+            .pspPayment(
+                PspPayment.builder().pspType(ORANGE_MONEY).id("MP260715.5678.D9E0F1").build())
+            .creationInstant(Instant.parse("2026-01-15T10:30:00Z"))
+            .verificationAttemptNb(0)
+            .payer(new User("mata@cu.te"))
+            .application(new Application("tsinjo", "tsinjo-api-key"))
+            .build());
+
+    var response = subject.exportPaymentsCsv(null, null, null, null);
+    assertNotNull(response.getBody());
+    var csv = new String(response.getBody(), StandardCharsets.UTF_8);
 
     assertEquals(200, response.getStatusCodeValue());
-    assertTrue(response.getHeaders().get(CONTENT_DISPOSITION).getFirst().contains("attachment"));
-    assertTrue(response.getHeaders().getContentType().toString().contains("text/csv"));
-    var body = new String(response.getBody());
-    assertTrue(body.contains("Email payeur"));
-    assertTrue(body.contains(email));
-    assertTrue(body.contains(appName));
+    assertEquals(readResource(), csv);
   }
 
+  @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
-  void exportPaymentsCsv_filters_by_date_range() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
+  void exportPaymentsCsv_empty_returns_header_only() throws IOException {
+    var app = new JApplication();
+    app.setName("EmptyApp");
+    app.setId("app-empty");
+    app.setApiKey("empty-api-key");
+    jApplicationRepository.save(app);
 
-    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
-
-    var response =
-        subject.exportPaymentsCsv(
-            appName, null, LocalDate.of(2020, 1, 1), LocalDate.of(2099, 1, 1));
+    var response = subject.exportPaymentsCsv("EmptyApp", null, null, null);
+    assertNotNull(response.getBody());
+    var csv = new String(response.getBody(), StandardCharsets.UTF_8);
 
     assertEquals(200, response.getStatusCodeValue());
-    var body = new String(response.getBody());
-    assertTrue(body.contains(email));
+    assertEquals(
+        "Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last"
+            + " verification;Scope;Application\n",
+        csv);
   }
 
-  @Test
-  void exportPaymentsCsv_outside_date_range_returns_header_only() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-
-    subject.createPayment(apiKey, randomEmail(), ORANGE_MONEY, randomUUID().toString(), null);
-
-    var response =
-        subject.exportPaymentsCsv(
-            appName, null, LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 2));
-
-    assertEquals(200, response.getStatusCodeValue());
-    var body = new String(response.getBody());
-    var lines = body.split("\n");
-    assertEquals(1, lines.length);
-  }
-
-  @Test
-  void exportPaymentsCsv_filename_contains_application_name() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-
-    subject.createPayment(apiKey, randomEmail(), ORANGE_MONEY, randomUUID().toString(), null);
-
-    var response = subject.exportPaymentsCsv(appName, null, null, null);
-
-    var disposition = response.getHeaders().get(CONTENT_DISPOSITION).getFirst();
-    assertTrue(disposition.contains("payments_" + appName + "_"));
+  private String readResource() throws IOException {
+    var resource = new ClassPathResource("csv/expected-export.csv");
+    try (var is = resource.getInputStream()) {
+      return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    }
   }
 
   private static String randomEmail() {

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -254,7 +254,7 @@ class PaymentControllerIT extends FacadeIT {
             .application(new Application("klioba", "klioba-api-key"))
             .build());
 
-    var response = subject.exportPaymentsCsv(null, null, null, null);
+    var response = subject.exportPaymentsCsv("klioba-api-key", null, null, null);
     assertNotNull(response.getBody());
     var csv = new String(response.getBody(), StandardCharsets.UTF_8);
 
@@ -271,7 +271,7 @@ class PaymentControllerIT extends FacadeIT {
     app.setApiKey("empty-api-key");
     jApplicationRepository.save(app);
 
-    var response = subject.exportPaymentsCsv("EmptyApp", null, null, null);
+    var response = subject.exportPaymentsCsv("empty-api-key", null, null, null);
     assertNotNull(response.getBody());
     var csv = new String(response.getBody(), StandardCharsets.UTF_8);
 

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -236,18 +236,11 @@ class PaymentControllerIT extends FacadeIT {
   @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
   void exportPaymentsCsv_with_data_matches_expected() throws IOException {
-    var klioba = new JApplication();
-    klioba.setName("klioba");
-    klioba.setId("app-klioba");
-    klioba.setApiKey("klioba-api-key");
-    jApplicationRepository.save(klioba);
-
-    var tsinjo = new JApplication();
-    tsinjo.setName("tsinjo");
-    tsinjo.setId("app-tsinjo");
-    tsinjo.setApiKey("tsinjo-api-key");
-    jApplicationRepository.save(tsinjo);
-
+    var app = new JApplication();
+    app.setName("klioba");
+    app.setId("app-klioba");
+    app.setApiKey("klioba-api-key");
+    jApplicationRepository.save(app);
     userRepository.save(new User("mata@cu.te"));
 
     paymentRepository.save(
@@ -259,17 +252,6 @@ class PaymentControllerIT extends FacadeIT {
             .verificationAttemptNb(0)
             .payer(new User("mata@cu.te"))
             .application(new Application("klioba", "klioba-api-key"))
-            .build());
-
-    paymentRepository.save(
-        Payment.builder()
-            .id("p2")
-            .pspPayment(
-                PspPayment.builder().pspType(ORANGE_MONEY).id("MP260715.5678.D9E0F1").build())
-            .creationInstant(Instant.parse("2026-01-15T10:30:00Z"))
-            .verificationAttemptNb(0)
-            .payer(new User("mata@cu.te"))
-            .application(new Application("tsinjo", "tsinjo-api-key"))
             .build());
 
     var response = subject.exportPaymentsCsv(null, null, null, null);

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -238,12 +238,6 @@ class PaymentControllerIT extends FacadeIT {
   @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
   void exportPaymentsCsv_with_data_matches_expected() throws IOException {
-    var admin = new JApplication();
-    admin.setName("ADMIN");
-    admin.setId("admin-app");
-    admin.setApiKey("admin-api-key");
-    jApplicationRepository.save(admin);
-
     var app = new JApplication();
     app.setName("klioba");
     app.setId("app-klioba");
@@ -273,12 +267,6 @@ class PaymentControllerIT extends FacadeIT {
   @DirtiesContext(methodMode = BEFORE_METHOD)
   @Test
   void exportPaymentsCsv_empty_returns_header_only() throws IOException {
-    var admin = new JApplication();
-    admin.setName("ADMIN");
-    admin.setId("admin-app");
-    admin.setApiKey("admin-api-key");
-    jApplicationRepository.save(admin);
-
     var app = new JApplication();
     app.setName("EmptyApp");
     app.setId("app-empty");
@@ -305,12 +293,6 @@ class PaymentControllerIT extends FacadeIT {
 
   @Test
   void exportPaymentsCsv_app_apiKey_rejected() {
-    var app = new JApplication();
-    app.setName("klioba");
-    app.setId("app-klioba");
-    app.setApiKey("klioba-api-key");
-    jApplicationRepository.save(app);
-
     assertThrows(
         UnauthorizedException.class,
         () -> subject.exportPaymentsCsv("klioba-api-key", "klioba", null, null, null));

--- a/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
+++ b/src/test/java/school/hei/vola/endpoint/rest/controller/PaymentControllerIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static org.springframework.test.annotation.DirtiesContext.MethodMode.BEFORE_METHOD;
 import static school.hei.vola.conf.TestData.ORANGE_REF_SUCCEEDED;
 import static school.hei.vola.model.VerificationStatus.FAILED;
@@ -220,6 +221,106 @@ class PaymentControllerIT extends FacadeIT {
     var events = eventCaptor.getValue();
     assertEquals(1, events.size());
     assertTrue(events.getFirst().getBucketKey().contains(bucketKey));
+  }
+
+  @Test
+  void exportPaymentsCsv_returns_csv_with_correct_headers() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+
+    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+
+    var response = subject.exportPaymentsCsv(appName, null, null, null);
+
+    assertEquals(200, response.getStatusCodeValue());
+    assertTrue(response.getHeaders().get(CONTENT_DISPOSITION).getFirst().contains("attachment"));
+    assertTrue(response.getHeaders().getContentType().toString().contains("text/csv"));
+    var body = new String(response.getBody());
+    assertTrue(body.contains("Email payeur"));
+    assertTrue(body.contains(email));
+    assertTrue(body.contains(appName));
+  }
+
+  @Test
+  void exportPaymentsCsv_filters_by_date_range() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+
+    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+
+    var response =
+        subject.exportPaymentsCsv(
+            appName, null, LocalDate.of(2020, 1, 1), LocalDate.of(2099, 1, 1));
+
+    assertEquals(200, response.getStatusCodeValue());
+    var body = new String(response.getBody());
+    assertTrue(body.contains(email));
+  }
+
+  @Test
+  void exportPaymentsCsv_outside_date_range_returns_header_only() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+
+    subject.createPayment(apiKey, randomEmail(), ORANGE_MONEY, randomUUID().toString(), null);
+
+    var response =
+        subject.exportPaymentsCsv(
+            appName, null, LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 2));
+
+    assertEquals(200, response.getStatusCodeValue());
+    var body = new String(response.getBody());
+    var lines = body.split("\n");
+    assertEquals(1, lines.length);
+  }
+
+  @Test
+  void exportPaymentsCsv_filename_contains_application_name() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+
+    subject.createPayment(apiKey, randomEmail(), ORANGE_MONEY, randomUUID().toString(), null);
+
+    var response = subject.exportPaymentsCsv(appName, null, null, null);
+
+    var disposition = response.getHeaders().get(CONTENT_DISPOSITION).getFirst();
+    assertTrue(disposition.contains("payments_" + appName + "_"));
+  }
+
+  @Test
+  void exportPaymentsCsv_with_all_returns_payments_from_all_apps() {
+    var app1 = randomJApplication();
+    var app2 = randomJApplication();
+    var email1 = randomEmail();
+    var email2 = randomEmail();
+
+    subject.createPayment(app1.getApiKey(), email1, ORANGE_MONEY, randomUUID().toString(), null);
+    subject.createPayment(app2.getApiKey(), email2, ORANGE_MONEY, randomUUID().toString(), null);
+
+    var response = subject.exportPaymentsCsv("all", null, null, null);
+
+    assertEquals(200, response.getStatusCodeValue());
+    var body = new String(response.getBody());
+    assertTrue(body.contains(email1));
+    assertTrue(body.contains(email2));
+  }
+
+  @Test
+  void exportPaymentsCsv_with_all_uses_all_in_filename() {
+    var app = randomJApplication();
+    subject.createPayment(
+        app.getApiKey(), randomEmail(), ORANGE_MONEY, randomUUID().toString(), null);
+
+    var response = subject.exportPaymentsCsv("all", null, null, null);
+
+    var disposition = response.getHeaders().get(CONTENT_DISPOSITION).getFirst();
+    assertTrue(disposition.contains("payments_all_"));
   }
 
   private static String randomEmail() {

--- a/src/test/java/school/hei/vola/service/PaymentServiceIT.java
+++ b/src/test/java/school/hei/vola/service/PaymentServiceIT.java
@@ -27,6 +27,7 @@ import school.hei.vola.conf.FacadeIT;
 import school.hei.vola.endpoint.event.EventProducer;
 import school.hei.vola.endpoint.event.model.PaymentVerificationRequested;
 import school.hei.vola.model.PaymentInfo;
+import school.hei.vola.repository.PaymentRepository;
 import school.hei.vola.repository.jpa.JApplicationRepository;
 import school.hei.vola.repository.jpa.model.JApplication;
 
@@ -35,6 +36,7 @@ class PaymentServiceIT extends FacadeIT {
   @Autowired PaymentService subject;
   @MockBean EventProducer eventProducerMocked;
   @Autowired JApplicationRepository jApplicationRepository;
+  @Autowired PaymentRepository paymentRepository;
 
   @Captor ArgumentCaptor<List<PaymentVerificationRequested>> eventCaptor;
 
@@ -405,6 +407,123 @@ class PaymentServiceIT extends FacadeIT {
     var pending = subject.countPending(appName, null, Instant.EPOCH, Instant.now());
 
     assertEquals(2, pending);
+  }
+
+  @Test
+  void buildPaymentsCsv_returns_header_and_data_rows() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+    var pspPaymentId = randomUUID().toString();
+
+    subject.createPayment(apiKey, email, ORANGE_MONEY, pspPaymentId, null);
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+    var lines = csv.split("\n");
+
+    assertEquals(2, lines.length);
+    assertTrue(lines[0].contains("Email payeur"));
+    assertTrue(lines[1].contains(email));
+    assertTrue(lines[1].contains(ORANGE_MONEY.name()));
+    assertTrue(lines[1].contains(pspPaymentId));
+    assertTrue(lines[1].contains(appName));
+    assertTrue(lines[1].contains("En vérification"));
+  }
+
+  @Test
+  void buildPaymentsCsv_no_payments_returns_header_only() {
+    var app = randomJApplication();
+    var appName = app.getName();
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+    var lines = csv.split("\n");
+
+    assertEquals(1, lines.length);
+    assertTrue(lines[0].contains("Email payeur"));
+  }
+
+  @Test
+  void buildPaymentsCsv_succeeded_status_label() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+
+    var created = subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+    var succeeded =
+        created.toBuilder()
+            .pspPayment(created.pspPayment().toBuilder().amount(5000).build())
+            .build();
+    paymentRepository.save(succeeded);
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+
+    assertTrue(csv.contains("Succ\u00e8s"));
+    assertTrue(csv.contains("5000"));
+  }
+
+  @Test
+  void buildPaymentsCsv_failed_status_label() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+
+    var created = subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+    var failed = created.toBuilder().verificationAttemptNb(10).build();
+    paymentRepository.save(failed);
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+
+    assertTrue(csv.contains("\u00c9chou\u00e9"));
+  }
+
+  @Test
+  void buildPaymentsCsv_escapes_semicolons_in_email() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var emailWithSemicolon = "test;special@cute.dev";
+
+    subject.createPayment(apiKey, emailWithSemicolon, ORANGE_MONEY, randomUUID().toString(), null);
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+
+    assertTrue(csv.contains("\"test;special@cute.dev\""));
+  }
+
+  @Test
+  void buildPaymentsCsv_empty_amount_and_dates_for_new_payment() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+
+    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+    var lines = csv.split("\n");
+    var columns = lines[1].split(";");
+
+    assertEquals("", columns[3]);
+    assertEquals("", columns[6]);
+  }
+
+  @Test
+  void buildPaymentsCsv_creation_instant_is_present() {
+    var app = randomJApplication();
+    var apiKey = app.getApiKey();
+    var appName = app.getName();
+    var email = randomEmail();
+
+    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
+
+    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
+    var lines = csv.split("\n");
+    var columns = lines[1].split(";");
+
+    assertTrue(columns[5].length() > 0);
   }
 
   private void createPayments(String apiKey, List<PaymentInfo> paymentInfos) {

--- a/src/test/java/school/hei/vola/service/PaymentServiceIT.java
+++ b/src/test/java/school/hei/vola/service/PaymentServiceIT.java
@@ -27,7 +27,6 @@ import school.hei.vola.conf.FacadeIT;
 import school.hei.vola.endpoint.event.EventProducer;
 import school.hei.vola.endpoint.event.model.PaymentVerificationRequested;
 import school.hei.vola.model.PaymentInfo;
-import school.hei.vola.repository.PaymentRepository;
 import school.hei.vola.repository.jpa.JApplicationRepository;
 import school.hei.vola.repository.jpa.model.JApplication;
 
@@ -36,7 +35,6 @@ class PaymentServiceIT extends FacadeIT {
   @Autowired PaymentService subject;
   @MockBean EventProducer eventProducerMocked;
   @Autowired JApplicationRepository jApplicationRepository;
-  @Autowired PaymentRepository paymentRepository;
 
   @Captor ArgumentCaptor<List<PaymentVerificationRequested>> eventCaptor;
 
@@ -407,123 +405,6 @@ class PaymentServiceIT extends FacadeIT {
     var pending = subject.countPending(appName, null, Instant.EPOCH, Instant.now());
 
     assertEquals(2, pending);
-  }
-
-  @Test
-  void buildPaymentsCsv_returns_header_and_data_rows() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
-    var pspPaymentId = randomUUID().toString();
-
-    subject.createPayment(apiKey, email, ORANGE_MONEY, pspPaymentId, null);
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-    var lines = csv.split("\n");
-
-    assertEquals(2, lines.length);
-    assertTrue(lines[0].contains("Email payeur"));
-    assertTrue(lines[1].contains(email));
-    assertTrue(lines[1].contains(ORANGE_MONEY.name()));
-    assertTrue(lines[1].contains(pspPaymentId));
-    assertTrue(lines[1].contains(appName));
-    assertTrue(lines[1].contains("En vérification"));
-  }
-
-  @Test
-  void buildPaymentsCsv_no_payments_returns_header_only() {
-    var app = randomJApplication();
-    var appName = app.getName();
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-    var lines = csv.split("\n");
-
-    assertEquals(1, lines.length);
-    assertTrue(lines[0].contains("Email payeur"));
-  }
-
-  @Test
-  void buildPaymentsCsv_succeeded_status_label() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
-
-    var created = subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
-    var succeeded =
-        created.toBuilder()
-            .pspPayment(created.pspPayment().toBuilder().amount(5000).build())
-            .build();
-    paymentRepository.save(succeeded);
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-
-    assertTrue(csv.contains("Succ\u00e8s"));
-    assertTrue(csv.contains("5000"));
-  }
-
-  @Test
-  void buildPaymentsCsv_failed_status_label() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
-
-    var created = subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
-    var failed = created.toBuilder().verificationAttemptNb(10).build();
-    paymentRepository.save(failed);
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-
-    assertTrue(csv.contains("\u00c9chou\u00e9"));
-  }
-
-  @Test
-  void buildPaymentsCsv_escapes_semicolons_in_email() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var emailWithSemicolon = "test;special@cute.dev";
-
-    subject.createPayment(apiKey, emailWithSemicolon, ORANGE_MONEY, randomUUID().toString(), null);
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-
-    assertTrue(csv.contains("\"test;special@cute.dev\""));
-  }
-
-  @Test
-  void buildPaymentsCsv_empty_amount_and_dates_for_new_payment() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
-
-    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-    var lines = csv.split("\n");
-    var columns = lines[1].split(";");
-
-    assertEquals("", columns[3]);
-    assertEquals("", columns[6]);
-  }
-
-  @Test
-  void buildPaymentsCsv_creation_instant_is_present() {
-    var app = randomJApplication();
-    var apiKey = app.getApiKey();
-    var appName = app.getName();
-    var email = randomEmail();
-
-    subject.createPayment(apiKey, email, ORANGE_MONEY, randomUUID().toString(), null);
-
-    var csv = subject.buildPaymentsCsv(appName, null, Instant.EPOCH, Instant.now());
-    var lines = csv.split("\n");
-    var columns = lines[1].split(";");
-
-    assertTrue(columns[5].length() > 0);
   }
 
   private void createPayments(String apiKey, List<PaymentInfo> paymentInfos) {

--- a/src/test/resources/csv/expected-export.csv
+++ b/src/test/resources/csv/expected-export.csv
@@ -1,3 +1,2 @@
 Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last verification;Scope;Application
 mata@cu.te;ORANGE_MONEY;MP260715.1234.A1B2C3;;Verifying;2026-01-15T10:30:00Z;;;klioba
-mata@cu.te;ORANGE_MONEY;MP260715.5678.D9E0F1;;Verifying;2026-01-15T10:30:00Z;;;tsinjo

--- a/src/test/resources/csv/expected-export.csv
+++ b/src/test/resources/csv/expected-export.csv
@@ -1,0 +1,3 @@
+Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last verification;Scope;Application
+mata@cu.te;ORANGE_MONEY;MP260715.1234.A1B2C3;;Verifying;2026-01-15T10:30:00Z;;;klioba
+mata@cu.te;ORANGE_MONEY;MP260715.5678.D9E0F1;;Verifying;2026-01-15T10:30:00Z;;;tsinjo


### PR DESCRIPTION
Add `/payments/export/csv` endpoint returning payments filtered by:
- adminKey (authenticates with admin API key from `ADMIN_API_KEY` env var)
- applicationName
- scope
- date range (startDate / endDate)

CSV format:
- Headers (**in English**): Payer email;PSP;Payment ref;Amount (Ar);Status;Creation date;Last verification;Scope;Application
- Status labels: Succeeded / Verifying / Failed
- Filename: payments_{applicationName}_{timestamp}.csv